### PR TITLE
IMPROVED: replaced *sync calls by async calls

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -6,11 +6,3 @@ import Drive from './classes/drive';
  * @return {Promise<Drive[]>} Promise resolves array of disks and their info.
  */
 export declare function getDiskInfo(): Promise<Drive[]>;
-/**
- * Get disk info according current platform in an syncronous way.
- *
- * @author Cristiam Mercado
- * @return {Drive[]} Array of disks and their info.
- * @throws {Error} Current platform must be win32, linux or darwin.
- */
-export declare function getDiskInfoSync(): Drive[];

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,42 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getDiskInfoSync = exports.getDiskInfo = void 0;
+exports.getDiskInfo = void 0;
 var darwin_1 = require("./platforms/darwin");
 var linux_1 = require("./platforms/linux");
 var windows_1 = require("./platforms/windows");
@@ -12,84 +48,32 @@ var utils_1 = require("./utils/utils");
  * @return {Promise<Drive[]>} Promise resolves array of disks and their info.
  */
 function getDiskInfo() {
-    return new Promise(function (resolve, reject) {
-        try {
-            var platform = utils_1.Utils.detectPlatform();
-            var drivesInfo = void 0;
+    return __awaiter(this, void 0, void 0, function () {
+        var platform;
+        return __generator(this, function (_a) {
+            platform = utils_1.Utils.detectPlatform();
             switch (platform) {
                 case 'aix': // IBM AIX platform
-                    reject(new Error("Platform not supported: " + platform));
-                    break;
+                    throw (new Error("Platform not supported: " + platform));
                 case 'android': // Android platform
-                    reject(new Error("Platform not supported: " + platform));
-                    break;
+                    throw (new Error("Platform not supported: " + platform));
                 case 'darwin': // Darwin platfrom(MacOS, IOS etc)
-                    drivesInfo = darwin_1.Darwin.run();
-                    resolve(drivesInfo);
-                    break;
+                    return [2 /*return*/, darwin_1.Darwin.run()];
                 case 'freebsd': // FreeBSD Platform
-                    drivesInfo = darwin_1.Darwin.run();
-                    resolve(drivesInfo);
-                    break;
+                    return [2 /*return*/, darwin_1.Darwin.run()];
                 case 'linux': // Linux Platform
-                    drivesInfo = linux_1.Linux.run();
-                    resolve(drivesInfo);
-                    break;
+                    return [2 /*return*/, linux_1.Linux.run()];
                 case 'openbsd': // OpenBSD platform
-                    drivesInfo = darwin_1.Darwin.run();
-                    resolve(drivesInfo);
-                    break;
+                    return [2 /*return*/, darwin_1.Darwin.run()];
                 case 'sunos': // SunOS platform
-                    reject(new Error("Platform not supported: " + platform));
-                    break;
+                    throw (new Error("Platform not supported: " + platform));
                 case 'win32': // windows platform
-                    drivesInfo = windows_1.Windows.run();
-                    resolve(drivesInfo);
-                    break;
+                    return [2 /*return*/, windows_1.Windows.run()];
                 default: // unknown platform
-                    reject(new Error("Platform not recognized: " + platform));
+                    throw (new Error("Platform not recognized: " + platform));
             }
-        }
-        catch (e) {
-            reject(e);
-        }
+            return [2 /*return*/];
+        });
     });
 }
 exports.getDiskInfo = getDiskInfo;
-/**
- * Get disk info according current platform in an syncronous way.
- *
- * @author Cristiam Mercado
- * @return {Drive[]} Array of disks and their info.
- * @throws {Error} Current platform must be win32, linux or darwin.
- */
-function getDiskInfoSync() {
-    var platform = utils_1.Utils.detectPlatform();
-    var drivesInfo;
-    switch (platform) {
-        case 'aix': // IBM AIX platform
-            throw new Error("Platform not supported: " + platform);
-        case 'android': // Android platform
-            throw new Error("Platform not supported: " + platform);
-        case 'darwin': // Darwin platfrom(MacOS, IOS etc)
-            drivesInfo = darwin_1.Darwin.run();
-            return drivesInfo;
-        case 'freebsd': // FreeBSD Platform
-            drivesInfo = darwin_1.Darwin.run();
-            return drivesInfo;
-        case 'linux': // Linux Platform
-            drivesInfo = linux_1.Linux.run();
-            return drivesInfo;
-        case 'openbsd': // OpenBSD platform
-            drivesInfo = darwin_1.Darwin.run();
-            return drivesInfo;
-        case 'sunos': // SunOS platform
-            throw new Error("Platform not supported: " + platform);
-        case 'win32': // windows platform
-            drivesInfo = windows_1.Windows.run();
-            return drivesInfo;
-        default: // unknown platform
-            throw new Error("Platform not recognized: " + platform);
-    }
-}
-exports.getDiskInfoSync = getDiskInfoSync;

--- a/dist/platforms/darwin.d.ts
+++ b/dist/platforms/darwin.d.ts
@@ -6,7 +6,7 @@ export declare class Darwin {
     /**
      * Execute specific OSX command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
-    static run(): Drive[];
+    static run(): Promise<Drive[]>;
 }

--- a/dist/platforms/darwin.js
+++ b/dist/platforms/darwin.js
@@ -1,4 +1,40 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -16,21 +52,31 @@ var Darwin = /** @class */ (function () {
     /**
      * Execute specific OSX command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
     Darwin.run = function () {
-        var drives = [];
-        var buffer = utils_1.Utils.execute(constants_1.Constants.DARWIN_COMMAND);
-        var lines = buffer.toString().split('\n');
-        lines.forEach(function (value, index, array) {
-            if (value !== '') {
-                var line = value.replace(/ +(?= )/g, '');
-                var tokens = line.split(' ');
-                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens.slice(5).join(' '));
-                drives.push(d);
-            }
+        return __awaiter(this, void 0, void 0, function () {
+            var drives, buffer, lines;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        drives = [];
+                        return [4 /*yield*/, utils_1.Utils.execute(constants_1.Constants.DARWIN_COMMAND)];
+                    case 1:
+                        buffer = _a.sent();
+                        lines = buffer.toString().split('\n');
+                        lines.forEach(function (value, index, array) {
+                            if (value !== '') {
+                                var line = value.replace(/ +(?= )/g, '');
+                                var tokens = line.split(' ');
+                                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens.slice(5).join(' '));
+                                drives.push(d);
+                            }
+                        });
+                        return [2 /*return*/, drives];
+                }
+            });
         });
-        return drives;
     };
     return Darwin;
 }());

--- a/dist/platforms/linux.d.ts
+++ b/dist/platforms/linux.d.ts
@@ -6,7 +6,7 @@ export declare class Linux {
     /**
      * Execute specific Linux command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
-    static run(): Drive[];
+    static run(): Promise<Drive[]>;
 }

--- a/dist/platforms/linux.js
+++ b/dist/platforms/linux.js
@@ -1,4 +1,40 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -16,21 +52,31 @@ var Linux = /** @class */ (function () {
     /**
      * Execute specific Linux command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
     Linux.run = function () {
-        var drives = [];
-        var buffer = utils_1.Utils.execute(constants_1.Constants.LINUX_COMMAND);
-        var lines = buffer.toString().split('\n');
-        lines.forEach(function (value) {
-            if (value !== '') {
-                var line = value.replace(/ +(?= )/g, '');
-                var tokens = line.split(' ');
-                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens.slice(5).join(' '));
-                drives.push(d);
-            }
+        return __awaiter(this, void 0, void 0, function () {
+            var drives, buffer, lines;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        drives = [];
+                        return [4 /*yield*/, utils_1.Utils.execute(constants_1.Constants.LINUX_COMMAND)];
+                    case 1:
+                        buffer = _a.sent();
+                        lines = buffer.toString().split('\n');
+                        lines.forEach(function (value) {
+                            if (value !== '') {
+                                var line = value.replace(/ +(?= )/g, '');
+                                var tokens = line.split(' ');
+                                var d = new drive_1.default(tokens[0], isNaN(parseFloat(tokens[1])) ? 0 : +tokens[1], isNaN(parseFloat(tokens[2])) ? 0 : +tokens[2], isNaN(parseFloat(tokens[3])) ? 0 : +tokens[3], tokens[4], tokens.slice(5).join(' '));
+                                drives.push(d);
+                            }
+                        });
+                        return [2 /*return*/, drives];
+                }
+            });
         });
-        return drives;
     };
     return Linux;
 }());

--- a/dist/platforms/windows.d.ts
+++ b/dist/platforms/windows.d.ts
@@ -6,7 +6,7 @@ export declare class Windows {
     /**
      * Execute specific Windows command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
-    static run(): Drive[];
+    static run(): Promise<Drive[]>;
 }

--- a/dist/platforms/windows.js
+++ b/dist/platforms/windows.js
@@ -1,4 +1,40 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -17,74 +53,86 @@ var Windows = /** @class */ (function () {
     /**
      * Execute specific Windows command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
     Windows.run = function () {
-        var drives = [];
-        var buffer = utils_1.Utils.execute(constants_1.Constants.WINDOWS_COMMAND);
-        var cp = utils_1.Utils.chcp();
-        var encoding = '';
-        switch (cp) {
-            case '65000': // UTF-7
-                encoding = 'UTF-7';
-                break;
-            case '65001': // UTF-8
-                encoding = 'UTF-8';
-                break;
-            default: // Other Encoding
-                if (/^-?[\d.]+(?:e-?\d+)?$/.test(cp)) {
-                    encoding = 'cp' + cp;
+        return __awaiter(this, void 0, void 0, function () {
+            var drives, buffer, cp, encoding, lines, newDiskIteration, caption, description, freeSpace, size;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        drives = [];
+                        return [4 /*yield*/, utils_1.Utils.execute(constants_1.Constants.WINDOWS_COMMAND)];
+                    case 1:
+                        buffer = _a.sent();
+                        return [4 /*yield*/, utils_1.Utils.chcp()];
+                    case 2:
+                        cp = _a.sent();
+                        encoding = '';
+                        switch (cp) {
+                            case '65000': // UTF-7
+                                encoding = 'UTF-7';
+                                break;
+                            case '65001': // UTF-8
+                                encoding = 'UTF-8';
+                                break;
+                            default: // Other Encoding
+                                if (/^-?[\d.]+(?:e-?\d+)?$/.test(cp)) {
+                                    encoding = 'cp' + cp;
+                                }
+                                else {
+                                    encoding = cp;
+                                }
+                        }
+                        buffer = iconv_lite_1.default.encode(iconv_lite_1.default.decode(buffer, encoding), 'UTF-8');
+                        lines = buffer.toString().split('\r\r\n');
+                        newDiskIteration = false;
+                        caption = '';
+                        description = '';
+                        freeSpace = 0;
+                        size = 0;
+                        lines.forEach(function (value) {
+                            if (value !== '') {
+                                var tokens = value.split('=');
+                                var section = tokens[0];
+                                var data = tokens[1];
+                                switch (section) {
+                                    case 'Caption':
+                                        caption = data;
+                                        newDiskIteration = true;
+                                        break;
+                                    case 'Description':
+                                        description = data;
+                                        break;
+                                    case 'FreeSpace':
+                                        freeSpace = isNaN(parseFloat(data)) ? 0 : +data;
+                                        break;
+                                    case 'Size':
+                                        size = isNaN(parseFloat(data)) ? 0 : +data;
+                                        break;
+                                }
+                            }
+                            else {
+                                if (newDiskIteration) {
+                                    var used = (size - freeSpace);
+                                    var percent = '0%';
+                                    if (size > 0) {
+                                        percent = Math.round((used / size) * 100) + '%';
+                                    }
+                                    var d = new drive_1.default(description, size, used, freeSpace, percent, caption);
+                                    drives.push(d);
+                                    newDiskIteration = false;
+                                    caption = '';
+                                    description = '';
+                                    freeSpace = 0;
+                                    size = 0;
+                                }
+                            }
+                        });
+                        return [2 /*return*/, drives];
                 }
-                else {
-                    encoding = cp;
-                }
-        }
-        buffer = iconv_lite_1.default.encode(iconv_lite_1.default.decode(buffer, encoding), 'UTF-8');
-        var lines = buffer.toString().split('\r\r\n');
-        var newDiskIteration = false;
-        var caption = '';
-        var description = '';
-        var freeSpace = 0;
-        var size = 0;
-        lines.forEach(function (value) {
-            if (value !== '') {
-                var tokens = value.split('=');
-                var section = tokens[0];
-                var data = tokens[1];
-                switch (section) {
-                    case 'Caption':
-                        caption = data;
-                        newDiskIteration = true;
-                        break;
-                    case 'Description':
-                        description = data;
-                        break;
-                    case 'FreeSpace':
-                        freeSpace = isNaN(parseFloat(data)) ? 0 : +data;
-                        break;
-                    case 'Size':
-                        size = isNaN(parseFloat(data)) ? 0 : +data;
-                        break;
-                }
-            }
-            else {
-                if (newDiskIteration) {
-                    var used = (size - freeSpace);
-                    var percent = '0%';
-                    if (size > 0) {
-                        percent = Math.round((used / size) * 100) + '%';
-                    }
-                    var d = new drive_1.default(description, size, used, freeSpace, percent, caption);
-                    drives.push(d);
-                    newDiskIteration = false;
-                    caption = '';
-                    description = '';
-                    freeSpace = 0;
-                    size = 0;
-                }
-            }
+            });
         });
-        return drives;
     };
     return Windows;
 }());

--- a/dist/utils/utils.d.ts
+++ b/dist/utils/utils.d.ts
@@ -12,13 +12,13 @@ export declare class Utils {
     /**
      * Get chcp value (only for Win32 platform).
      *
-     * @return {string} Platform: win32.
+     * @return {Promise<string>} Platform: win32.
      */
-    static chcp(): string;
+    static chcp(): Promise<string>;
     /**
      * Executes a command in SO console.
      *
-     * @param {Buffer} command: Command to execute.
+     * @param {Promise<Buffer>} command: Command to execute.
      */
-    static execute(command: string): Buffer;
+    static execute(command: string): Promise<Buffer>;
 }

--- a/dist/utils/utils.js
+++ b/dist/utils/utils.js
@@ -18,10 +18,48 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Utils = void 0;
 var os = __importStar(require("os"));
+var util_1 = require("util");
 var child_process_1 = require("child_process");
+var execAsync = util_1.promisify(child_process_1.exec);
 /**
  * Class with utilitary methods.
  */
@@ -39,18 +77,38 @@ var Utils = /** @class */ (function () {
     /**
      * Get chcp value (only for Win32 platform).
      *
-     * @return {string} Platform: win32.
+     * @return {Promise<string>} Platform: win32.
      */
     Utils.chcp = function () {
-        return child_process_1.execSync('chcp').toString().split(':')[1].trim();
+        return __awaiter(this, void 0, void 0, function () {
+            var stdout;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, execAsync('chcp', { windowsHide: true })];
+                    case 1:
+                        stdout = (_a.sent()).stdout;
+                        return [2 /*return*/, stdout.toString().split(':')[1].trim()];
+                }
+            });
+        });
     };
     /**
      * Executes a command in SO console.
      *
-     * @param {Buffer} command: Command to execute.
+     * @param {Promise<Buffer>} command: Command to execute.
      */
     Utils.execute = function (command) {
-        return child_process_1.execSync(command, { windowsHide: true, encoding: 'buffer' });
+        return __awaiter(this, void 0, void 0, function () {
+            var stdout;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, execAsync(command, { windowsHide: true, encoding: 'buffer' })];
+                    case 1:
+                        stdout = (_a.sent()).stdout;
+                        return [2 /*return*/, stdout];
+                }
+            });
+        });
     };
     return Utils;
 }());

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,93 +10,35 @@ import {Utils} from './utils/utils';
  * @author Cristiam Mercado
  * @return {Promise<Drive[]>} Promise resolves array of disks and their info.
  */
-export function getDiskInfo(): Promise<Drive[]> {
-
-    return new Promise((resolve, reject) => {
-
-        try {
-
-            const platform = Utils.detectPlatform();
-            let drivesInfo: Drive[];
-
-            switch (platform) {
-                case 'aix': // IBM AIX platform
-                    reject(new Error(`Platform not supported: ${platform}`));
-                    break;
-                case 'android': // Android platform
-                    reject(new Error(`Platform not supported: ${platform}`));
-                    break;
-                case 'darwin': // Darwin platfrom(MacOS, IOS etc)
-                    drivesInfo = Darwin.run();
-                    resolve(drivesInfo);
-                    break;
-                case 'freebsd': // FreeBSD Platform
-                    drivesInfo = Darwin.run();
-                    resolve(drivesInfo);
-                    break;
-                case 'linux': // Linux Platform
-                    drivesInfo = Linux.run();
-                    resolve(drivesInfo);
-                    break;
-                case 'openbsd': // OpenBSD platform
-                    drivesInfo = Darwin.run();
-                    resolve(drivesInfo);
-                    break;
-                case 'sunos': // SunOS platform
-                    reject(new Error(`Platform not supported: ${platform}`));
-                    break;
-                case 'win32': // windows platform
-                    drivesInfo = Windows.run();
-                    resolve(drivesInfo);
-                    break;    
-                default: // unknown platform
-                    reject(new Error(`Platform not recognized: ${platform}`));
-            }
-
-        } catch (e) {
-            reject(e);
-        }
-
-    })
-
-}
-
-/**
- * Get disk info according current platform in an syncronous way.
- *
- * @author Cristiam Mercado
- * @return {Drive[]} Array of disks and their info.
- * @throws {Error} Current platform must be win32, linux or darwin.
- */
-export function getDiskInfoSync(): Drive[] {
-
+export async function getDiskInfo(): Promise<Drive[]> {
     const platform = Utils.detectPlatform();
-    let drivesInfo: Drive[];
 
     switch (platform) {
         case 'aix': // IBM AIX platform
-            throw new Error("Platform not supported: " + platform);
-        case 'android': // Android platform
-            throw new Error("Platform not supported: " + platform);
-        case 'darwin': // Darwin platfrom(MacOS, IOS etc)
-            drivesInfo = Darwin.run();
-            return drivesInfo;
-        case 'freebsd': // FreeBSD Platform
-            drivesInfo = Darwin.run();
-            return drivesInfo;
-        case 'linux': // Linux Platform
-            drivesInfo = Linux.run();
-            return drivesInfo;
-        case 'openbsd': // OpenBSD platform
-            drivesInfo = Darwin.run();
-            return drivesInfo;
-        case 'sunos': // SunOS platform
-            throw new Error("Platform not supported: " + platform);
-        case 'win32': // windows platform
-            drivesInfo = Windows.run();
-            return drivesInfo;
-        default: // unknown platform
-            throw new Error("Platform not recognized: " + platform);
-    }
+            throw(new Error(`Platform not supported: ${platform}`));
 
+        case 'android': // Android platform
+            throw(new Error(`Platform not supported: ${platform}`));
+
+        case 'darwin': // Darwin platfrom(MacOS, IOS etc)
+            return Darwin.run();
+
+        case 'freebsd': // FreeBSD Platform
+            return Darwin.run();
+
+        case 'linux': // Linux Platform
+            return Linux.run();
+
+        case 'openbsd': // OpenBSD platform
+            return Darwin.run();
+
+        case 'sunos': // SunOS platform
+            throw(new Error(`Platform not supported: ${platform}`));
+
+        case 'win32': // windows platform
+            return Windows.run();
+
+        default: // unknown platform
+            throw(new Error(`Platform not recognized: ${platform}`));
+    }
 }

--- a/src/platforms/darwin.ts
+++ b/src/platforms/darwin.ts
@@ -11,12 +11,12 @@ export class Darwin {
     /**
      * Execute specific OSX command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
-    public static run(): Drive[] {
+    public static async run(): Promise<Drive[]> {
 
         const drives: Drive[] = [];
-        const buffer = Utils.execute(Constants.DARWIN_COMMAND);
+        const buffer = await Utils.execute(Constants.DARWIN_COMMAND);
         const lines = buffer.toString().split('\n');
 
         lines.forEach((value, index, array) => {

--- a/src/platforms/linux.ts
+++ b/src/platforms/linux.ts
@@ -11,12 +11,12 @@ export class Linux {
     /**
      * Execute specific Linux command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
-    public static run(): Drive[] {
+    public static async run(): Promise<Drive[]> {
 
         const drives: Drive[] = [];
-        const buffer = Utils.execute(Constants.LINUX_COMMAND);
+        const buffer = await Utils.execute(Constants.LINUX_COMMAND);
         const lines = buffer.toString().split('\n');
 
         lines.forEach((value) => {

--- a/src/platforms/windows.ts
+++ b/src/platforms/windows.ts
@@ -12,14 +12,14 @@ export class Windows {
     /**
      * Execute specific Windows command to get disk info.
      *
-     * @return {Drive[]} List of drives and their info.
+     * @return {Promise<Drive[]>} List of drives and their info.
      */
-    public static run(): Drive[] {
+    public static async run(): Promise<Drive[]> {
 
         const drives: Drive[] = [];
-        let buffer = Utils.execute(Constants.WINDOWS_COMMAND);
+        let buffer = await Utils.execute(Constants.WINDOWS_COMMAND);
         
-        const cp = Utils.chcp();
+        const cp = await Utils.chcp();
         let encoding = '';
         switch (cp) {
             case '65000': // UTF-7

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,8 @@
 import * as os from 'os';
-import {execSync} from 'child_process';
+import { promisify } from 'util';
+import { exec } from 'child_process';
 
+const execAsync = promisify(exec)
 /**
  * Class with utilitary methods.
  */
@@ -18,18 +20,20 @@ export class Utils {
     /**
      * Get chcp value (only for Win32 platform).
      *
-     * @return {string} Platform: win32.
+     * @return {Promise<string>} Platform: win32.
      */
-     public static chcp(): string {
-        return execSync('chcp', {windowsHide: true}).toString().split(':')[1].trim();
+     public static async chcp(): Promise<string> {
+        const { stdout } = await execAsync('chcp', {windowsHide: true})
+        return stdout.toString().split(':')[1].trim();
     }
 
     /**
      * Executes a command in SO console.
      *
-     * @param {Buffer} command: Command to execute.
+     * @param {Promise<Buffer>} command: Command to execute.
      */
-    public static execute(command: string): Buffer {
-        return execSync(command,{windowsHide: true, encoding: 'buffer'});
+    public static async execute(command: string): Promise<Buffer> {
+        const { stdout } = await execAsync(command,{windowsHide: true, encoding: 'buffer'});
+        return stdout
     }
 }

--- a/test/aix.spec.ts
+++ b/test/aix.spec.ts
@@ -1,5 +1,5 @@
 import {Utils} from '../src/utils/utils';
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 
 describe('node-disk-info-aix', () => {
 
@@ -28,11 +28,5 @@ describe('node-disk-info-aix', () => {
             .catch(reason => {
                 done();
             });
-    });
-
-    it('should not generate disks list info sync for unsupported so', () => {
-        spyOn(Utils, 'detectPlatform').and.callFake(() => 'aix');
-
-        expect(() => getDiskInfoSync()).toThrowError('Platform not supported: aix');
     });
 });

--- a/test/android.spec.ts
+++ b/test/android.spec.ts
@@ -1,5 +1,5 @@
 import {Utils} from '../src/utils/utils';
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 
 describe('node-disk-info-android', () => {
 
@@ -28,11 +28,5 @@ describe('node-disk-info-android', () => {
             .catch(reason => {
                 done();
             });
-    });
-
-    it('should not generate disks list info sync for unsupported so', () => {
-        spyOn(Utils, 'detectPlatform').and.callFake(() => 'android');
-
-        expect(() => getDiskInfoSync()).toThrowError('Platform not supported: android');
     });
 });

--- a/test/freebsd.spec.ts
+++ b/test/freebsd.spec.ts
@@ -1,4 +1,4 @@
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 import {Utils} from '../src/utils/utils';
 import * as os from 'os';
 
@@ -20,7 +20,7 @@ describe('node-disk-info-freebsd', () => {
     beforeAll(() => {
         if (os.platform() !== 'freebsd') {
             spyOn(Utils, 'detectPlatform').and.callFake(() => 'freebsd');
-            spyOn(Utils, 'execute').and.callFake((command: string) => FREEBSD_COMMAND_RESPONSE);
+            spyOn(Utils, 'execute').and.callFake((command: string) => Promise.resolve(FREEBSD_COMMAND_RESPONSE));
         }
     });
 
@@ -68,38 +68,4 @@ describe('node-disk-info-freebsd', () => {
                 done.fail(reason);
             });
     });
-
-    it('should generate disks list info sync for FreeBSD', () => {
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disk info sync for FreeBSD', () => {
-        const values = getDiskInfoSync();
-
-        expect(values.length).toBeGreaterThan(0);
-
-        const disk = values[0];
-
-        expect(disk.filesystem).toBeDefined();
-        expect(typeof disk.filesystem).toEqual('string');
-
-        expect(disk.blocks).toBeDefined();
-        expect(typeof disk.blocks).toEqual('number');
-
-        expect(disk.used).toBeDefined();
-        expect(typeof disk.used).toEqual('number');
-
-        expect(disk.available).toBeDefined();
-        expect(typeof disk.available).toEqual('number');
-
-        expect(disk.capacity).toBeDefined();
-        expect(typeof disk.capacity).toEqual('string');
-
-        expect(disk.mounted).toBeDefined();
-        expect(typeof disk.mounted).toEqual('string');
-    });
-
 });

--- a/test/linux.spec.ts
+++ b/test/linux.spec.ts
@@ -1,4 +1,4 @@
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 import {Utils} from '../src/utils/utils';
 import * as os from 'os';
 
@@ -20,7 +20,7 @@ describe('node-disk-info-linux', () => {
     beforeAll(() => {
         if (os.platform() !== 'linux') {
             spyOn(Utils, 'detectPlatform').and.callFake(() => 'linux');
-            spyOn(Utils, 'execute').and.callFake((command: string) => LINUX_COMMAND_RESPONSE);
+            spyOn(Utils, 'execute').and.callFake((command: string) => Promise.resolve(LINUX_COMMAND_RESPONSE));
         }
     });
 
@@ -67,38 +67,4 @@ describe('node-disk-info-linux', () => {
                 done.fail(reason);
             });
     });
-
-    it('should generate disks list info sync for Linux', () => {
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disk info sync for Linux', () => {
-        const values = getDiskInfoSync();
-
-        expect(values.length).toBeGreaterThan(0);
-
-        const disk = values[0];
-
-        expect(disk.filesystem).toBeDefined();
-        expect(typeof disk.filesystem).toEqual('string');
-
-        expect(disk.blocks).toBeDefined();
-        expect(typeof disk.blocks).toEqual('number');
-
-        expect(disk.used).toBeDefined();
-        expect(typeof disk.used).toEqual('number');
-
-        expect(disk.available).toBeDefined();
-        expect(typeof disk.available).toEqual('number');
-
-        expect(disk.capacity).toBeDefined();
-        expect(typeof disk.capacity).toEqual('string');
-
-        expect(disk.mounted).toBeDefined();
-        expect(typeof disk.mounted).toEqual('string');
-    });
-
 });

--- a/test/macos.spec.ts
+++ b/test/macos.spec.ts
@@ -1,4 +1,4 @@
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 import {Utils} from '../src/utils/utils';
 import * as os from 'os';
 
@@ -20,7 +20,7 @@ describe('node-disk-info-macos', () => {
     beforeAll(() => {
         if (os.platform() !== 'darwin') {
             spyOn(Utils, 'detectPlatform').and.callFake(() => 'darwin');
-            spyOn(Utils, 'execute').and.callFake((command: string) => DARWIN_COMMAND_RESPONSE);
+            spyOn(Utils, 'execute').and.callFake((command: string) => Promise.resolve(DARWIN_COMMAND_RESPONSE));
         }
     });
 
@@ -68,38 +68,4 @@ describe('node-disk-info-macos', () => {
                 done.fail(reason);
             });
     });
-
-    it('should generate disks list info sync for Mac OS', () => {
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disk info sync for Mac OS', () => {
-        const values = getDiskInfoSync();
-
-        expect(values.length).toBeGreaterThan(0);
-
-        const disk = values[0];
-
-        expect(disk.filesystem).toBeDefined();
-        expect(typeof disk.filesystem).toEqual('string');
-
-        expect(disk.blocks).toBeDefined();
-        expect(typeof disk.blocks).toEqual('number');
-
-        expect(disk.used).toBeDefined();
-        expect(typeof disk.used).toEqual('number');
-
-        expect(disk.available).toBeDefined();
-        expect(typeof disk.available).toEqual('number');
-
-        expect(disk.capacity).toBeDefined();
-        expect(typeof disk.capacity).toEqual('string');
-
-        expect(disk.mounted).toBeDefined();
-        expect(typeof disk.mounted).toEqual('string');
-    });
-
 });

--- a/test/openbsd.spec.ts
+++ b/test/openbsd.spec.ts
@@ -1,4 +1,4 @@
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 import {Utils} from '../src/utils/utils';
 import * as os from 'os';
 
@@ -20,7 +20,7 @@ describe('node-disk-info-openbsd', () => {
     beforeAll(() => {
         if (os.platform() !== 'openbsd') {
             spyOn(Utils, 'detectPlatform').and.callFake(() => 'openbsd');
-            spyOn(Utils, 'execute').and.callFake((command: string) => OPENBSD_COMMAND_RESPONSE);
+            spyOn(Utils, 'execute').and.callFake((command: string) => Promise.resolve(OPENBSD_COMMAND_RESPONSE));
         }
     });
 
@@ -68,38 +68,4 @@ describe('node-disk-info-openbsd', () => {
                 done.fail(reason);
             });
     });
-
-    it('should generate disks list info sync for OpenBSD', () => {
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disk info sync for OpenBSD', () => {
-        const values = getDiskInfoSync();
-
-        expect(values.length).toBeGreaterThan(0);
-
-        const disk = values[0];
-
-        expect(disk.filesystem).toBeDefined();
-        expect(typeof disk.filesystem).toEqual('string');
-
-        expect(disk.blocks).toBeDefined();
-        expect(typeof disk.blocks).toEqual('number');
-
-        expect(disk.used).toBeDefined();
-        expect(typeof disk.used).toEqual('number');
-
-        expect(disk.available).toBeDefined();
-        expect(typeof disk.available).toEqual('number');
-
-        expect(disk.capacity).toBeDefined();
-        expect(typeof disk.capacity).toEqual('string');
-
-        expect(disk.mounted).toBeDefined();
-        expect(typeof disk.mounted).toEqual('string');
-    });
-
 });

--- a/test/sunos.spec.ts
+++ b/test/sunos.spec.ts
@@ -1,5 +1,5 @@
 import {Utils} from '../src/utils/utils';
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 
 describe('node-disk-info-sunos', () => {
 
@@ -28,11 +28,5 @@ describe('node-disk-info-sunos', () => {
             .catch(reason => {
                 done();
             });
-    });
-
-    it('should not generate disks list info sync for unsupported so', () => {
-        spyOn(Utils, 'detectPlatform').and.callFake(() => 'sunos');
-
-        expect(() => getDiskInfoSync()).toThrowError('Platform not supported: sunos');
     });
 });

--- a/test/unknown.spec.ts
+++ b/test/unknown.spec.ts
@@ -1,5 +1,5 @@
 import {Utils} from '../src/utils/utils';
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 
 describe('node-disk-info-unknown', () => {
 
@@ -28,11 +28,5 @@ describe('node-disk-info-unknown', () => {
             .catch(reason => {
                 done();
             });
-    });
-
-    it('should not generate disks list info sync for unsupported so', () => {
-        spyOn(Utils, 'detectPlatform').and.callFake(() => 'anyosnotsupported');
-
-        expect(() => getDiskInfoSync()).toThrowError('Platform not recognized: anyosnotsupported');
     });
 });

--- a/test/win32.spec.ts
+++ b/test/win32.spec.ts
@@ -1,4 +1,4 @@
-import {getDiskInfo, getDiskInfoSync} from '../src';
+import {getDiskInfo} from '../src';
 import {Utils} from '../src/utils/utils';
 import * as os from 'os';
 
@@ -32,13 +32,13 @@ describe('node-disk-info-win32', () => {
     beforeAll(() => {
         if (os.platform() !== 'win32') {
             spyOn(Utils, 'detectPlatform').and.callFake(() => 'win32');
-            spyOn(Utils, 'execute').and.callFake(() => WINDOWS_COMMAND_RESPONSE);
+            spyOn(Utils, 'execute').and.callFake(() => Promise.resolve(WINDOWS_COMMAND_RESPONSE));
         }
     });
 
     it('should generate disks list info for Windows', (done) => {
         if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
+            spyOn(Utils, 'chcp').and.callFake(() => Promise.resolve('65001'));
         }
         getDiskInfo()
             .then(values => {
@@ -54,7 +54,7 @@ describe('node-disk-info-win32', () => {
 
     it('should generate disk info for Windows', (done) => {
         if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
+            spyOn(Utils, 'chcp').and.callFake(() => Promise.resolve('65001'));
         }
         getDiskInfo()
             .then(values => {
@@ -86,76 +86,4 @@ describe('node-disk-info-win32', () => {
                 done.fail(reason);
             });
     });
-
-    it('should generate disks list info sync for Windows', () => {
-        if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
-        }
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disk info sync for Windows', () => {
-        if (os.platform() !== 'win32') {
-            spyOn(Utils, 'chcp').and.callFake(() => '65001');
-        }
-        const values = getDiskInfoSync();
-
-        expect(values.length).toBeGreaterThan(0);
-
-        const disk = values[0];
-
-        expect(disk.filesystem).toBeDefined();
-        expect(typeof disk.filesystem).toEqual('string');
-
-        expect(disk.blocks).toBeDefined();
-        expect(typeof disk.blocks).toEqual('number');
-
-        expect(disk.used).toBeDefined();
-        expect(typeof disk.used).toEqual('number');
-
-        expect(disk.available).toBeDefined();
-        expect(typeof disk.available).toEqual('number');
-
-        expect(disk.capacity).toBeDefined();
-        expect(typeof disk.capacity).toEqual('string');
-
-        expect(disk.mounted).toBeDefined();
-        expect(typeof disk.mounted).toEqual('string');
-    });
-
-    it('should generate disks list info sync for Windows chcp 65000', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => '65000');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disks list info sync for Windows chcp 65001', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => '65001');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disks list info sync for Windows chcp ascii', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => 'ascii');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
-    it('should generate disks list info sync for Windows chcp 1252', () => {
-        spyOn(Utils, 'chcp').and.callFake(() => '1252');
-        const values = getDiskInfoSync();
-
-        expect(values).toBeDefined();
-        expect(values.length).toBeGreaterThanOrEqual(0);
-    });
-
 });


### PR DESCRIPTION
This allows to remove these warnings from Chrome:
> [Violation] Forced reflow while executing JavaScript took xxms

Also removed sync versions of nodeDiskInfo: cannot see a reason why this would be needed.